### PR TITLE
Remove end of life .NET 5 and add .NET 8

### DIFF
--- a/StitcherBoy/StitcherBoy.csproj
+++ b/StitcherBoy/StitcherBoy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{4B0B68DC-07A9-46E7-AE6C-57AD11F1645A}</ProjectGuid>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\StitcherBoy.XML</DocumentationFile>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <DebugType>full</DebugType>

--- a/Tests/StringsRetoucher/TestApplication.txt
+++ b/Tests/StringsRetoucher/TestApplication.txt
@@ -2,4 +2,4 @@
 AssemblyPath=obj\Debug\TestApplication.exe
 
 ..\..\..\TestApplication5
-AssemblyPath=obj\Debug\net5.0\TestApplication5.dll
+AssemblyPath=obj\Debug\net6.0\TestApplication5.dll

--- a/Tests/StringsRetoucher5/StringsRetoucher.targets
+++ b/Tests/StringsRetoucher5/StringsRetoucher.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <StringsRetoucherTool>"$(MSBuildThisFileDirectory)bin\Debug\net5.0\StringsRetoucher5.exe"</StringsRetoucherTool>
+    <StringsRetoucherTool>"$(MSBuildThisFileDirectory)bin\Debug\net6.0\StringsRetoucher5.exe"</StringsRetoucherTool>
   </PropertyGroup>
 
   <Target Name="StringsRetoucher" AfterTargets="CoreCompile">

--- a/Tests/StringsRetoucher5/StringsRetoucher5.csproj
+++ b/Tests/StringsRetoucher5/StringsRetoucher5.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>StringsRetoucher</RootNamespace>
     <AssemblyName>StringsRetoucher5</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyTitle>StringsRetoucher</AssemblyTitle>
     <Product>StringsRetoucher</Product>
     <Copyright>Copyright ©  2015</Copyright>

--- a/Tests/StringsRetoucher5/TestApplication.txt
+++ b/Tests/StringsRetoucher5/TestApplication.txt
@@ -2,4 +2,4 @@
 AssemblyPath=obj\Debug\TestApplication.exe
 
 ..\..\..\TestApplication5
-AssemblyPath=obj\Debug\net5.0\TestApplication5.dll
+AssemblyPath=obj\Debug\net6.0\TestApplication5.dll

--- a/Tests/TestApplication5/TestApplication5.csproj
+++ b/Tests/TestApplication5/TestApplication5.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
.NET 5 is end of life (ended in May 2022). Added .NET 8 as MrAdvice also has one.